### PR TITLE
raw_frame/audio_packet.h fixed member name error in struct sdata

### DIFF
--- a/raw_frame/audio_packet.h
+++ b/raw_frame/audio_packet.h
@@ -60,7 +60,7 @@ class AudioPacket {
             unsigned int _rate;
             unsigned int _channels;
             size_t _sample_size;
-            uint8_t data[0];
+            uint8_t _data[0];
         };
 
         uint8_t *_data;


### PR DESCRIPTION
AudioPacket uses the struct sdata as defined in audio_packet.h. This struct has the member data, but the member _data is called.

I renamed the data field to _data
