### PR TITLE
Add 1080i60 and 1080p60 to supported formats

### DIFF
--- a/drivers/decklink.cpp
+++ b/drivers/decklink.cpp
@@ -55,6 +55,8 @@ static struct decklink_norm norms[] = {
     { "1080/59.94i", 30000, 1001, bmdModeHD1080i5994, 1920, 1080 },
     { "NTSC", 30000, 1001, bmdModeNTSC, 720, 486 },
     { "1080/30p", 30000, 1000, bmdModeHD1080p30, 1920, 1080 },
+    { "1080/60i", 30000, 1000, bmdModeHD1080i6000, 1920, 1080 },
+    { "1080/60p", 30000, 1000, bmdModeHD1080p6000, 1920, 1080 }, // Time may not sync properly for video in this format
 };
 
 static struct decklink_connection connections[] = {

--- a/replay/replay_config.rb.example
+++ b/replay/replay_config.rb.example
@@ -6,6 +6,8 @@ configure do |app|
 	# 0 = 1080i 59.94
 	# 1 = 480i NTSC
 	# 2 = 1080p 30.00
+	# 3 = 1080i 60.00
+	# 4 = 1080p 60.00 - Caution using this format -- Time may appear 2x as fast, at the moment.
 	#
 	# valid inputs:
 	#


### PR DESCRIPTION
* Add 1080i60 and 1080p60 to supported formats
* Update replay_config.rb.example to include these formats.
* A warning has been included for using 1080p60 under the current system.